### PR TITLE
Feat calc running balances

### DIFF
--- a/backend/db_migrations/2025-09-04-add_is_reference_to_account_history.sql
+++ b/backend/db_migrations/2025-09-04-add_is_reference_to_account_history.sql
@@ -1,0 +1,6 @@
+-- Add is_reference column to track reference balances set by the user
+ALTER TABLE account_history
+ADD COLUMN is_reference BOOLEAN DEFAULT FALSE;
+
+-- Optional: Index for potentially faster lookups of reference balances
+-- CREATE INDEX idx_account_history_is_reference ON account_history(accountid, is_reference);

--- a/backend/src/routes/accounts.js
+++ b/backend/src/routes/accounts.js
@@ -12,40 +12,45 @@ const logger = require('../Logger.js');
 // and then selecting the latest of those
 // it then joins this with the account table to get the account details
 const sql = `
-SELECT a.*,
-       b.balance,
-       b.datetime as balance_datetime,
-       b.src as balance_source
-FROM account a
+SELECT
+    a.*, -- Select all columns from the account table
+    COALESCE(ah.balance, t_latest.balance) AS balance, -- Prioritize account_history balance
+    COALESCE(ah.datetime, t_latest.datetime) AS balance_datetime, -- Prioritize account_history datetime
+    CASE
+        WHEN ah.accountid IS NOT NULL THEN 'account_history' -- Source is account_history if found
+        ELSE 'transaction' -- Otherwise, source is transaction
+    END AS balance_source
+FROM
+    account a
 LEFT JOIN (
-    SELECT account,
-           MAX(datetime) AS datetime,
-           balance,
-           src
+    -- Find the latest entry using ROW_NUMBER() ordered by datetime DESC, then is_reference DESC, then rowid DESC
+    SELECT accountid, datetime, balance
     FROM (
-        SELECT account,
-               MAX(t.datetime) as datetime,
-               rowid, -- i was hoping to get this working
-               balance,
-               'transaction' AS src
-        FROM 'transaction' t
-        GROUP BY account
-
-        UNION ALL
-
-        SELECT accountid AS account,
-               datetime,
-               MAX(rowid) AS rowid,
-               balance,
-               'account_history' AS src
-        FROM "account_history"
-        GROUP BY accountid
-		
-    ) AS combined
-    GROUP BY account
-) AS b
-ON a.accountid = b.account
-WHERE 1=1
+        SELECT
+            h.accountid,
+            h.datetime,
+            h.balance,
+            h.is_reference, -- Include is_reference for ordering
+            ROW_NUMBER() OVER(PARTITION BY h.accountid ORDER BY h.datetime DESC, h.is_reference DESC, h.rowid DESC) as rn
+        FROM account_history h
+    )
+    WHERE rn = 1
+) ah ON a.accountid = ah.accountid
+LEFT JOIN (
+    -- Find the latest transaction entry using ROW_NUMBER() ordered by datetime DESC, then rowid DESC
+    SELECT account, datetime, balance
+    FROM (
+        SELECT
+            t.account,
+            t.datetime,
+            t.balance,
+            ROW_NUMBER() OVER(PARTITION BY t.account ORDER BY t.datetime DESC, t.rowid DESC) as rn
+        FROM "transaction" t
+        WHERE t.balance IS NOT NULL -- Only consider transactions with a balance
+    )
+    WHERE rn = 1
+) t_latest ON a.accountid = t_latest.account AND ah.accountid IS NULL -- Join ONLY if no account_history was found
+WHERE 1=1 -- Placeholder for potential future WHERE clauses on 'a'
 `
 const interestSql = `
 SELECT historyid,

--- a/backend/src/routes/accounts.js
+++ b/backend/src/routes/accounts.js
@@ -96,7 +96,7 @@ router.get('/api/accounts', async (req, res) => {
 router.get('/api/accounts/:id', async (req, res) => {
     try {
         const { id } = req.params;
-        const account = db.db.prepare(`${sql} AND accountid = ?`).get(id);
+        const account = db.db.prepare(`${sql} AND a.accountid = ?`).get(id); // Specify a.accountid
 
         // get interest data and merge it in
         const sqlFinal = interestSql + " AND accountid = ?"

--- a/frontend/src/account_add_balance/AccountAddBalanceDialog.jsx
+++ b/frontend/src/account_add_balance/AccountAddBalanceDialog.jsx
@@ -9,7 +9,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { CalendarIcon } from "lucide-react"
 import httpClient from "@/lib/httpClient" // adjust path if needed
 import { useToast } from "@/components/ui/use-toast.js"
-
+import { Checkbox } from "@/components/ui/checkbox" // Import Checkbox
 import {
     DialogTitle,
     DialogHeader,
@@ -21,7 +21,7 @@ export function AccountAddBalanceDialog({ accountid, onSuccess }) {
     const [date, setDate] = useState(new Date())
     const [time, setTime] = useState(format(new Date(), "HH:mm"))
     const { toast } = useToast()
-
+    const [isReference, setIsReference] = useState(false) // State for checkbox
     function sanitizeAmount(input) {
         return input.replace(/[^0-9.-]+/g, "") // removes $, commas, etc.
     }
@@ -37,6 +37,7 @@ export function AccountAddBalanceDialog({ accountid, onSuccess }) {
         console.log("Account ID:", accountid)
         console.log("Amount:", amount)
         console.log("Balance as of:", combinedDate.toISOString())
+        console.log("Is Reference:", isReference) // Log state
 
         const cleanedAmount = sanitizeAmount(amount)
         const numericAmount = parseFloat(cleanedAmount)
@@ -47,6 +48,7 @@ export function AccountAddBalanceDialog({ accountid, onSuccess }) {
             balance: numericAmount,
             datetime: isoDatetime,
             data: { "from": "saved from user (X) on frontend" },
+            is_reference: isReference, // Pass state to saveBalance
         })
 
         if (error) {
@@ -60,16 +62,19 @@ export function AccountAddBalanceDialog({ accountid, onSuccess }) {
     }    // utils/accountBalanceApi.js or similar
 
 
-    async function saveBalance({ accountid, datetime, balance, data }) {
+    // Update function signature to accept is_reference
+    async function saveBalance({ accountid, datetime, balance, data, is_reference }) {
         try {
+            // Pass is_reference in the POST payload
             const response = await httpClient.post("account_balance", {
                 accountid,
                 datetime,
                 balance,
                 data,
+                is_reference, // Include is_reference in the payload
             })
 
-            return { data: response.data, error: null, isLoading: false }
+            return { data: response.data, error: null, isLoading: false } // Correctly placed return
         } catch (err) {
             const apiErrors = err.response?.data?.errors
             let errorMsg
@@ -144,6 +149,21 @@ export function AccountAddBalanceDialog({ accountid, onSuccess }) {
                             className="w-[120px]"
                         />
                     </div>
+                </div>
+
+                {/* Reference Balance Checkbox */}
+                <div className="flex items-center space-x-2">
+                    <Checkbox
+                        id="is-reference"
+                        checked={isReference}
+                        onCheckedChange={setIsReference}
+                    />
+                    <label
+                        htmlFor="is-reference"
+                        className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                    >
+                        Make this the reference balance
+                    </label>
                 </div>
 
                 {/* Submit button */}

--- a/frontend/src/accounts/AccountsPage.jsx
+++ b/frontend/src/accounts/AccountsPage.jsx
@@ -70,7 +70,9 @@ const AccountsPage = () => {
 
   // Update filtered accounts when the search term changes
   useEffect(() => {
-    setFilteredAccounts(filterAccounts(accounts, searchTerm));
+    const filtered = filterAccounts(accounts, searchTerm);
+    console.log('Accounts after text filter:', filtered); // <-- Log after text filter
+    setFilteredAccounts(filtered);
   }, [accounts, searchTerm]);
 
 
@@ -79,9 +81,12 @@ const AccountsPage = () => {
   //////////////////
   // setup the data
   useEffect(() => {
+    console.log('--- Processing accounts ---');
+    console.log('Raw data from API:', data); // <-- Log raw data
     if (data) {
 
       const relevantAccounts = showInactive ? data : data.filter(acc => acc.status !== "inactive");
+      console.log('Relevant accounts after inactive filter:', relevantAccounts); // <-- Log after inactive filter
 
       // Create a lookup map for quick parent reference
       const accountMap = Object.fromEntries(relevantAccounts.map(acc => [acc.accountid, { ...acc }]));
@@ -106,6 +111,7 @@ const AccountsPage = () => {
 
       // Step 2: Remove child accounts (keep only top-level parents)
       const updatedAccounts = Object.values(accountMap);
+      console.log('Accounts after parent/child processing:', updatedAccounts); // <-- Log after parent/child processing
 
       // Sort accounts by custom sortOrder
       const sortOrder = ["Checking", "Savings", "Crypto", "Investment", "Credit", "Mortgage"];
@@ -121,6 +127,7 @@ const AccountsPage = () => {
         // If types are the same, sort by balance (descending order: highest balance first)
         return b.balance - a.balance;
       });
+      console.log('Accounts after sorting:', sortedAccounts); // <-- Log after sorting
 
       setAccounts(sortedAccounts);
 
@@ -160,7 +167,7 @@ const AccountsPage = () => {
 
         {filteredAccounts &&
           filteredAccounts
-            .filter((acc) => acc.category === category) // only liability or asset accounts
+            .filter((acc) => acc.category === category || (category === 'asset' && acc.category === 'imported')) // Show 'imported' with 'asset'
             .filter((acc) => !acc.parentid) // only top-level accounts
             .map((account, index) => (
               <React.Fragment key={account.accountid}>{renderRow(account)}</React.Fragment>

--- a/frontend/src/rules/QuickRuleModal.jsx
+++ b/frontend/src/rules/QuickRuleModal.jsx
@@ -1,0 +1,188 @@
+import { useState, useRef, useEffect } from "react"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { AlertCircle } from "lucide-react"
+import { Input } from "@/components/ui/input.jsx"
+import { ReactSelect } from "@/components/ReactSelect.jsx"
+import { useFetchTags } from "@/tags/TagApiHooks.js"
+import { Button } from "@/components/ui/button.jsx"
+import { useToast } from "@/components/ui/use-toast.js"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { useUpdateRules } from "@/rules/RuleApiHooks.jsx"
+
+export default function QuickRuleModal({ initialRuleString = '', onSaveComplete = null }) {
+  const { toast } = useToast();
+  
+  // Create a ref for the rule input field to focus it
+  const ruleInputRef = useRef(null);
+  
+  // Form state
+  const [ruleData, setRuleData] = useState({ rule: initialRuleString, tag: [], party: [] });
+  const [tagData, setTagData] = useState([]);
+  const [partyData, setPartyData] = useState([]);
+  const [ruleString, setRuleString] = useState(initialRuleString);
+  
+  // Loading and error states
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+  
+  // API hooks
+  const { create } = useUpdateRules();
+  
+  // Focus and select the rule input text when the component mounts
+  useEffect(() => {
+    if (ruleInputRef.current) {
+      ruleInputRef.current.focus();
+      ruleInputRef.current.select();
+    }
+  }, []);
+  
+  // Update rule string when initialRuleString changes
+  useEffect(() => {
+    setRuleString(initialRuleString);
+    setRuleData(prevState => ({ ...prevState, rule: initialRuleString }));
+  }, [initialRuleString]);
+  
+  // Tags handlers
+  const handleTagChange = selectedValues => {
+    setTagData(selectedValues);
+    setRuleData(prevState => ({ ...prevState, tag: selectedValues }));
+  };
+  
+  // Parties handlers
+  const handlePartyChange = selectedValues => {
+    setPartyData(selectedValues);
+    setRuleData(prevState => ({ ...prevState, party: selectedValues }));
+  };
+  
+  // Create rule handler
+  async function createRule(evt) {
+    evt.preventDefault();
+    
+    // Prevent multiple submissions
+    if (isSubmitting) return;
+    
+    setIsSubmitting(true);
+    
+    try {
+      const { data, error } = await create(ruleData);
+      
+      if (error) {
+        setError(error);
+        setIsSubmitting(false);
+        return;
+      } else {
+        toast({ description: 'Rule created successfully', duration: 1000 });
+        setError(null);
+        
+        // Add a small delay to ensure the rule is fully processed
+        // before closing the modal and refreshing the transaction list
+        setTimeout(() => {
+          // Call the onSaveComplete callback
+          if (onSaveComplete) {
+            onSaveComplete();
+          }
+          setIsSubmitting(false);
+        }, 300);
+      }
+    } catch (unexpectedError) {
+      console.error("Unexpected error:", unexpectedError);
+      setError("Unexpected error occurred");
+      setIsSubmitting(false);
+    }
+  }
+  
+  return (
+    <Card className="text-sm w-full">
+      <CardHeader>
+        <CardTitle>New Quick Rule</CardTitle>
+        <CardDescription>
+          When specific conditions occur, automatically add Tags or Merchants
+        </CardDescription>
+      </CardHeader>
+      
+      <CardContent>
+        {error && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Error</AlertTitle>
+            <AlertDescription>
+              {error}
+            </AlertDescription>
+          </Alert>
+        )}
+        
+        <form onSubmit={createRule}>
+          <div className="flex flex-col gap-3">
+            <div>
+              <div className="py-2 text-sm text-muted-foreground">
+                When these conditions match ...
+              </div>
+              
+              <div className="grid grid-cols-[auto_auto_auto_auto_auto] gap-3 items-center">
+                <div className="col-span-6">
+                  <Input
+                    ref={ruleInputRef}
+                    value={ruleString}
+                    name="rule"
+                    onChange={event => {
+                      setRuleString(event.target.value);
+                      setRuleData(prevState => ({ ...prevState, rule: event.target.value }));
+                    }}
+                    autoComplete="off"
+                  />
+                </div>
+                <div className="col-span-6 text-sm text-muted-foreground">
+                  <p>description = 'Costco'</p>
+                  <p>description = /^Costco.*Stuff/i (note the i for case insensitivity)</p>
+                  <p>amount &gt; 50</p>
+                  <p>account_number = /1547$/</p>
+                  <p>description = 'Costco' AND amount &gt; 50</p>
+                </div>
+              </div>
+            </div>
+            
+            <div>
+              <div className="py-2 text-sm text-muted-foreground">
+                Add these tags
+              </div>
+              <ReactSelect
+                onChange={handleTagChange}
+                optionsAsArray={useFetchTags('tags').data}
+                valueAsArray={tagData}
+                isMulti={true}
+                isCreatable={true}
+                coloredPills={true}
+                isClearable={true}
+                closeMenuOnSelect={false}
+                placeholder="Add a tag..."
+              />
+            </div>
+            
+            <div>
+              <div className="py-2 text-sm text-muted-foreground">
+                Add this counterparty / merchant
+              </div>
+              <ReactSelect
+                onChange={handlePartyChange}
+                optionsAsArray={useFetchTags('parties').data}
+                valueAsArray={partyData}
+                isMulti={false}
+                isCreatable={true}
+                coloredPills={true}
+                isClearable={true}
+                closeMenuOnSelect={true}
+                placeholder="Add a party..."
+              />
+            </div>
+            
+            <div className="flex justify-between">
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? 'Saving...' : 'Save'}
+              </Button>
+            </div>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/transactions/TransactionColumnDefinitions.jsx
+++ b/frontend/src/transactions/TransactionColumnDefinitions.jsx
@@ -4,8 +4,9 @@ import { EditableDescriptionCell } from '@/transactions/EditableDescriptionCell.
 import HeaderCell from "@/components/data-table/HeaderCell.jsx"
 import { TransactionTagsDisplay } from "@/transactions/TransactionTagsDisplay.jsx"
 import { Currency } from "@/components/CurrencyDisplay.jsx"
+import { Button } from "@/components/ui/button.jsx"
 
-export function createColumnDefinitions(onTransactionUpdate, t) {
+export function createColumnDefinitions(onTransactionUpdate, t, onQuickRuleClick) {
 
   return [
     {
@@ -185,7 +186,30 @@ export function createColumnDefinitions(onTransactionUpdate, t) {
       meta: {
         displayName: t("Party")
       }
-    }
+    },
 
+    // Actions column with Quick Rule button
+    {
+      id: 'actions',
+      header: props => <HeaderCell align='center' {...props} />,
+      cell: ({ row }) => {
+        const description = row.original.description;
+        return (
+          <div className="flex justify-center">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onQuickRuleClick?.(description)}
+              title="Create a rule based on this description"
+            >
+              Quick Rule
+            </Button>
+          </div>
+        );
+      },
+      meta: {
+        displayName: t("Actions")
+      }
+    }
   ];
 }


### PR DESCRIPTION
Added ability to calculate running balances for accounts where transaction feed does not contain balances. Adds new checkbox "Set reference balance" when setting a balance. If checked, then this balance is used to calculate daily balances both forward and backwards, based on transactions. Only one reference balance can be used per account. Balances are recalculated when a reference balance is set, and on import. 